### PR TITLE
PhoneNumber library

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.json]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.editorconfig      export-ignore
+/.github            export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.lando.yml         export-ignore
+/phpunit.xml        export-ignore
+/pint.json          export-ignore
+/tests              export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,5 @@
 /phpunit.xml        export-ignore
 /pint.json          export-ignore
 /tests              export-ignore
+/README.md          export-ignore
+/CONTRIBUTING.md    export-ignore

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+Description / context for this PR (e.g., GitHub issue/discussion # or Slack conversation link).
+
+**This PR does the following**
+
+-
+
+**To Review:**
+
+- [ ] Step 1
+- [ ] Step 2

--- a/.github/workflows/laravel-pint.yml
+++ b/.github/workflows/laravel-pint.yml
@@ -1,0 +1,14 @@
+name: PHP Linting
+on: pull_request
+jobs:
+  phplint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Laravel Pint
+        uses: aglipanci/laravel-pint-action@1.0.0
+        with:
+          verboseMode: true
+          testMode: true

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,41 @@
+name: PHPUnit Tests
+on: pull_request
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.1]
+        stability: [prefer-stable]
+        include:
+          - laravel: 9.*
+            testbench: 7.*
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite3, pdo_sqlite, bcmath, soap, intl, fileinfo
+          coverage: none
+
+      - name: Setup problem matchers
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: List Installed Dependencies
+        run: composer show -D
+
+      - name: Run PHPUnit tests
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ build
 composer.lock
 coverage
 docs
-phpunit.xml
 testbench.yaml
 vendor
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.idea
+.phpunit.result.cache
+build
+composer.lock
+coverage
+docs
+phpunit.xml
+testbench.yaml
+vendor
+node_modules
+*.local.*

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,14 @@
+name: cd-laravel-helpers
+recipe: laravel
+config:
+  webroot: ./public
+  php: 8.1
+  composer_version: 2-latest
+
+tooling:
+  phpunit:
+    service: appserver
+    description: "Run PHP Unit tests: lando phpunit"
+  pint:
+    service: appserver
+    description: "Run Laravel Pint: lando pint"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+## Pull requests
+
+GitHub pull requests are required and all PRs must pass phpunit and pint testing. 
+
+## Testing
+
+```bash
+php vendor/bin/phpunit
+```
+
+## Code Styling
+
+```shell
+php vendor/bin/pint --test
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# CD-LaravelHelpers
+# Cornell Custom Dev - Laravel Helpers
+
+A collection of Laravel utilities for Cornell Custom Development projects.
+
+## Installation
+You can install the package via composer:
+
+```bash
+composer require cornell-custom-dev/laravel-helpers
+```
+
+## Usage
+
+### PhoneNumber
+A class for parsing and formatting a phone number. It parses a wide range of user-formatted input, incorporating a best-guess approach to determining the region a number is from. It formats numbers for user display and for href "tel" numbers that are appropriate when dialing from the US.
+
+This class is a wrapper for [propaganistas/laravel-phone](https://github.com/Propaganistas/Laravel-Phone), which is built on a PHP port of Google's libphonenumber library. The Laravel Phone package provides additional features that may be of use, including Laravel validation rules, but generally requires a more technical knowledge of international phone number formatting.
+
+Examples:
+
+```php
+$phoneNumber = new PhoneNumber('6072551111');
+echo $phoneNumber->getNumber();
+// Outputs '+16072551111'
+
+echo $phoneNumber->getNumberFormattedForUS();
+// Outputs '(607) 255-1111'
+
+$phoneNumber = new PhoneNumber('+41446681800');
+echo $phoneNumber->getNumberFormattedForUS();
+// Outputs '+41 44 668 18 00'
+
+$phoneNumber = new PhoneNumber('44 668 1800', '41');
+echo $phoneNumber->getNumberFormattedForUS();
+// Outputs '+41 44 668 18 00'
+
+echo $phoneNumber->getNumberFormattedForTel();
+// Outputs '+41446681800'
+```
+
+See [PhoneNumberTest.php](./tests/PhoneNumberTest.php) for additional usage examples.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "php": "^8.1"
+    "php": "^8.1",
     "propaganistas/laravel-phone": "^4.4"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "cornell-custom-dev/laravel-helpers",
+  "description": "A collection of Laravel utilities for Cornell Custom Development",
+  "type": "library",
+  "require": {
+    "php": "^8.1",
+    "propaganistas/laravel-phone": "^4.4"
+  },
+  "require-dev": {
+    "laravel/pint": "^1.0",
+    "phpunit/phpunit": "^9.5"
+  },
+  "license": "MIT",
+  "autoload": {
+    "psr-4": {
+      "CornellCustomDev\\LaravelHelpers\\": "src",
+      "CornellCustomDev\\LaravelHelpers\\Tests\\": "tests"
+    }
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    verbose="true"
+    testdox="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+>
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="All">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,3 @@
+{
+  "preset": "laravel"
+}

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace CornellCustomDev\LaravelHelpers;
+
+use Exception;
+use Giggsey\Locale\Locale;
+use Illuminate\Support\Facades\Log;
+use libphonenumber\NumberParseException;
+use libphonenumber\PhoneNumberUtil;
+use Propaganistas\LaravelPhone\PhoneNumber as LaravelPhoneNumber;
+
+class PhoneNumber
+{
+    private ?LaravelPhoneNumber $phoneNumber;
+
+    private string $sourceNumber;
+
+    private ?string $sourceCountryCallingCode;
+
+    private bool $isValid = false;
+
+    public function __construct(string $number, ?string $countryCallingCode = null)
+    {
+        $this->sourceNumber = $number;
+        $this->sourceCountryCallingCode = $countryCallingCode ?: null;
+        try {
+            $this->phoneNumber = $this->parseNumber($number, $countryCallingCode);
+        } catch (Exception $exception) {
+            Log::info('PhoneNumber '.$number.' '.$exception->getMessage());
+        }
+    }
+
+    public function getCountry(): ?string
+    {
+        if (is_null($this->phoneNumber)) {
+            return null;
+        }
+
+        return $this->phoneNumber->getCountry();
+    }
+
+    public function isValid(): bool
+    {
+        if (! $this->isValid) {
+            return false;
+        }
+
+        return ! is_null($this->getCountry());
+    }
+
+    public static function getCountryListWithIntlCode()
+    {
+        $phoneNumberUtil = PhoneNumberUtil::getInstance();
+        $phoneCountries = collect(Locale::getAllCountriesForLocale('en'))
+            ->sort()
+            ->mapWithKeys(function ($country, $code) use ($phoneNumberUtil) {
+                // "US" => "United States (1)",
+                return [$code => "$country ({$phoneNumberUtil->getCountryCodeForRegion($code)})"];
+            });
+
+        return $phoneCountries;
+    }
+
+    public function getSourceNumber(): string
+    {
+        return $this->sourceNumber;
+    }
+
+    public function getCallingCode(): ?int
+    {
+        if (! $this->isValid()) {
+            return null;
+        }
+        $regionCode = $this->phoneNumber->getCountry();
+        $phoneUtil = PhoneNumberUtil::getInstance();
+
+        return $phoneUtil->getCountryCodeForRegion($regionCode);
+    }
+
+    public function getNumberWithoutCallingCode(): string
+    {
+        if (! $this->isValid()) {
+            return $this->getNumber();
+        }
+
+        $callingCode = $this->getCallingCode();
+        $numberWithoutCode = str_replace("+$callingCode", '', $this->phoneNumber->formatE164());
+
+        return $numberWithoutCode;
+    }
+
+    private function parseNumber(string $number, ?string $countryCallingCode = null): ?LaravelPhoneNumber
+    {
+        // If we don't have a calling code, just use the number directly
+        if (empty($countryCallingCode)) {
+            $phoneNumber = LaravelPhoneNumber::make($number, 'US');
+            if (self::isValidNumber($phoneNumber)) {
+                $this->isValid = true;
+
+                return $phoneNumber;
+            }
+            $phoneNumber = LaravelPhoneNumber::make('+'.trim('+', $number), 'US');
+            if (self::isValidNumber($phoneNumber)) {
+                $this->isValid = true;
+
+                return $phoneNumber;
+            }
+
+            return null;
+        }
+
+        // Assume good data first...
+        $phoneNumber = LaravelPhoneNumber::make('+'.$countryCallingCode.$number, 'US');
+        if (self::isValidNumber($phoneNumber)) {
+            $this->isValid = true;
+
+            return $phoneNumber;
+        }
+
+        // Didn't get parsable data, so try converting the country code
+        $countryCallingCode = ltrim($countryCallingCode, '0');
+        $phoneNumber = LaravelPhoneNumber::make('+'.$countryCallingCode.$number, 'US');
+        if (self::isValidNumber($phoneNumber)) {
+            $this->isValid = true;
+
+            return $phoneNumber;
+        }
+
+        return null;
+    }
+
+    public static function isValidNumber(LaravelPhoneNumber $phoneNumber): bool
+    {
+        try {
+            $phoneNumber->getCountry();
+            $phoneNumber->formatE164();
+
+            return true;
+        } catch (NumberParseException) {
+            return false;
+        }
+    }
+
+    public static function getCountryCallingCode(string $regionCode): ?int
+    {
+        $phoneUtil = PhoneNumberUtil::getInstance();
+        $countryCode = $phoneUtil->getCountryCodeForRegion($regionCode);
+
+        return $countryCode == 0 ? null : $countryCode;
+    }
+
+    public function getNumber(): string
+    {
+        if (! $this->isValid()) {
+            return trim($this->sourceCountryCallingCode.' '.$this->sourceNumber);
+        }
+
+        return $this->phoneNumber->formatE164();
+    }
+
+    public function getNumberFormattedForUS(): string
+    {
+        if (! $this->isValid()) {
+            return $this->getNumber();
+        }
+        if ($this->getCountry() == 'US') {
+            return $this->phoneNumber->formatNational();
+        }
+
+        return $this->phoneNumber->formatInternational();
+    }
+
+    public function getNumberFormattedForTel(): string
+    {
+        if (! $this->isValid()) {
+            return $this->getNumber();
+        }
+
+        return $this->phoneNumber->formatForMobileDialingInCountry('US');
+    }
+
+    public static function formatNumberForUS(string $number): string
+    {
+        $phoneNumber = new self($number);
+
+        return $phoneNumber->getNumberFormattedForUS();
+    }
+
+    public static function formatNumberForTel(string $number): string
+    {
+        $phoneNumber = new self($number);
+
+        return $phoneNumber->getNumberFormattedForTel();
+    }
+}

--- a/tests/PhoneNumberTest.php
+++ b/tests/PhoneNumberTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace CornellCustomDev\LaravelHelpers\Tests;
+
+use CornellCustomDev\LaravelHelpers\PhoneNumber;
+use Propaganistas\LaravelPhone\PhoneNumber as LaravelPhoneNumber;
+
+class PhoneNumberTest extends TestCase
+{
+    public function testCanValidateNumber()
+    {
+        $phoneNumber = LaravelPhoneNumber::make('6072551111', 'US');
+        $isValid = PhoneNumber::isValidNumber($phoneNumber);
+        $this->assertTrue($isValid);
+
+        $phoneNumber = LaravelPhoneNumber::make('2551111', 'US');
+        $isValid = PhoneNumber::isValidNumber($phoneNumber);
+        $this->assertFalse($isValid);
+    }
+
+    public function testCanParseNumber()
+    {
+        $phoneNumber = new PhoneNumber('6072551111');
+        $this->assertTrue($phoneNumber->isValid());
+
+        $phoneNumber = new PhoneNumber('607-255-1111');
+        $this->assertTrue($phoneNumber->isValid());
+
+        $phoneNumber = new PhoneNumber('(607) 255-1111');
+        $this->assertTrue($phoneNumber->isValid());
+
+        $phoneNumber = new PhoneNumber('2551111');
+        $this->assertFalse($phoneNumber->isValid());
+
+        $phoneNumber = new PhoneNumber('6072551111', '1');
+        $this->assertTrue($phoneNumber->isValid());
+
+        $phoneNumber = new PhoneNumber('6072551111', '001');
+        $this->assertTrue($phoneNumber->isValid());
+
+        $phoneNumber = new PhoneNumber('607255123x4', '1');
+        $this->assertFalse($phoneNumber->isValid());
+    }
+
+    public function testCanParseNumberWithoutCallingCode()
+    {
+        $phoneNumber = new PhoneNumber('6072551111');
+
+        $this->assertTrue($phoneNumber->isValid());
+    }
+
+    public function testCanGetCallingCode()
+    {
+        $phoneNumber = new PhoneNumber('6072551111');
+
+        $this->assertEquals('+1', $phoneNumber->getCallingCode());
+    }
+
+    public function testCanGetNumberWithoutCallingCode()
+    {
+        $phoneNumber = new PhoneNumber('+16072551111');
+
+        $this->assertEquals('6072551111', $phoneNumber->getNumberWithoutCallingCode());
+    }
+
+    public function testCanGetFormattedNumber()
+    {
+        $phoneNumber = new PhoneNumber('6072551111');
+
+        $this->assertEquals('+16072551111', $phoneNumber->getNumber());
+    }
+
+    public function testCanDefaultToSourceNumber()
+    {
+        $phoneNumber = new PhoneNumber('607-255-1111', '+255');
+
+        $this->assertEquals('+255 607-255-1111', $phoneNumber->getNumber());
+    }
+
+    public function testCanGetNumberFormattedForUS()
+    {
+        $phoneNumber = PhoneNumber::formatNumberForUS('6072551111');
+
+        $this->assertEquals('(607) 255-1111', $phoneNumber);
+    }
+
+    public function testCanGetInternationalNumberFormattedForUS()
+    {
+        $phoneNumber = new PhoneNumber('+41446681800');
+        $this->assertEquals('+41 44 668 18 00', $phoneNumber->getNumberFormattedForUS());
+
+        $phoneNumber = new PhoneNumber('44 668 1800', '41');
+        $this->assertEquals('+41 44 668 18 00', $phoneNumber->getNumberFormattedForUS());
+
+        // If no region code is unambiguous, present the number as provided
+        $phoneNumber = new PhoneNumber('41 44 668 1800');
+        $this->assertEquals('41 44 668 1800', $phoneNumber->getNumberFormattedForUS());
+    }
+
+    public function testCanGetNumberFormattedForTel()
+    {
+        $phoneNumber = PhoneNumber::formatNumberForTel('6072551111');
+        $this->assertEquals('+16072551111', $phoneNumber);
+
+        $phoneNumber = new PhoneNumber('44 668 1800', '41');
+        $this->assertEquals('+41446681800', $phoneNumber->getNumberFormattedForTel());
+    }
+
+    public function testCanGetCallingCodeForRegion()
+    {
+        $phoneNumber = PhoneNumber::getCountryCallingCode('US');
+
+        $this->assertEquals('+1', $phoneNumber);
+    }
+
+    public function testCanGetCountryList()
+    {
+        $list = PhoneNumber::getCountryListWithIntlCode();
+
+        $this->assertArrayHasKey('US', $list);
+        $this->assertEquals('United States (1)', $list['US']);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace CornellCustomDev\LaravelHelpers\Tests;
+
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        // additional setup
+    }
+}


### PR DESCRIPTION
Sets up initial repo config and adds a PhoneNumber library

**This PR does the following**

- Adds standard set of configuration files for a Laravel package with unit testing and linting (note: these were prototyped or directly copied from the [Laravel Starter Kit](https://github.com/CU-CommunityApps/CD-LaravelStarterKit) and [spatie/package-skeleton-laravel](https://github.com/spatie/package-skeleton-laravel))
- Adds PhoneNumber library class (see [README.md](https://github.com/CU-CommunityApps/CD-LaravelHelpers/blob/initial-build/README.md) for details)

**To Review:**

- [ ] Compare general package files with standards you are familiar with
- [ ] Review the README for clarity and accuracy
- [ ] Extra credit review: download locally and run phpunit tests